### PR TITLE
Fix registry serializer static registration to work with forge 34.1.27+

### DIFF
--- a/src/main/java/thut/tech/common/TechCore.java
+++ b/src/main/java/thut/tech/common/TechCore.java
@@ -25,7 +25,7 @@ import thut.tech.common.blocks.lift.ControllerTile;
 import thut.tech.common.entity.EntityLift;
 import thut.tech.common.handlers.ConfigHandler;
 import thut.tech.common.items.ItemLinker;
-import thut.tech.common.items.RecipeReset;
+import thut.tech.common.util.RecipeSerializers;
 
 @Mod(value = Reference.MOD_ID)
 public class TechCore
@@ -60,12 +60,6 @@ public class TechCore
             controller.setRegistryName(TechCore.LIFTCONTROLLER.getRegistryName());
             event.getRegistry().register(controller);
             ThutCore.THUTICON = new ItemStack(TechCore.LINKER);
-        }
-
-        @SubscribeEvent
-        public static void registerRecipes(final RegistryEvent.Register<IRecipeSerializer<?>> event)
-        {
-            event.getRegistry().register(RecipeReset.SERIALIZER);
         }
 
         @SubscribeEvent
@@ -111,6 +105,9 @@ public class TechCore
         FMLJavaModLoadingContext.get().getModEventBus().addListener(TechCore.proxy::setup);
         // Register the doClientStuff method for modloading
         FMLJavaModLoadingContext.get().getModEventBus().addListener(TechCore.proxy::setupClient);
+
+        // Register recipe serializers
+        RecipeSerializers.RECIPE_SERIALIZERS.register(FMLJavaModLoadingContext.get().getModEventBus());
 
         // Register Config stuff
         Config.setupConfigs(TechCore.config, Reference.MOD_ID, Reference.MOD_ID);

--- a/src/main/java/thut/tech/common/items/RecipeReset.java
+++ b/src/main/java/thut/tech/common/items/RecipeReset.java
@@ -4,16 +4,13 @@ import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.IRecipeSerializer;
 import net.minecraft.item.crafting.SpecialRecipe;
-import net.minecraft.item.crafting.SpecialRecipeSerializer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 import thut.tech.common.TechCore;
+import thut.tech.common.util.RecipeSerializers;
 
 public class RecipeReset extends SpecialRecipe
 {
-    public static final IRecipeSerializer<RecipeReset> SERIALIZER = IRecipeSerializer.register("thuttech:resetlinker",
-            new SpecialRecipeSerializer<>(RecipeReset::new));
-
     public RecipeReset(final ResourceLocation idIn)
     {
         super(idIn);
@@ -38,7 +35,7 @@ public class RecipeReset extends SpecialRecipe
     @Override
     public IRecipeSerializer<?> getSerializer()
     {
-        return RecipeReset.SERIALIZER;
+        return RecipeSerializers.RECIPE_RESET_SERIALIZER.get();
     }
 
     @Override

--- a/src/main/java/thut/tech/common/util/RecipeSerializers.java
+++ b/src/main/java/thut/tech/common/util/RecipeSerializers.java
@@ -1,0 +1,31 @@
+package thut.tech.common.util;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.item.crafting.IRecipeSerializer;
+import net.minecraft.item.crafting.SpecialRecipeSerializer;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.fml.RegistryObject;
+import net.minecraftforge.registries.DeferredRegister;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import thut.tech.Reference;
+import thut.tech.common.items.RecipeReset;
+
+public class RecipeSerializers
+{
+	public static final DeferredRegister<IRecipeSerializer<?>> RECIPE_SERIALIZERS = DeferredRegister.create(
+			ForgeRegistries.RECIPE_SERIALIZERS, Reference.MOD_ID
+	);
+
+	public static final RegistryObject<SpecialRecipeSerializer<RecipeReset>> RECIPE_RESET_SERIALIZER = RECIPE_SERIALIZERS.register(
+			"resetlinker", special(RecipeReset::new)
+	);
+
+	private static <T extends IRecipe<?>> Supplier<SpecialRecipeSerializer<T>> special(Function<ResourceLocation, T> create)
+	{
+		return () -> new SpecialRecipeSerializer<>(create);
+	}
+}


### PR DESCRIPTION
Forge 34.1.27+ has a breaking change in that you can no longer statically register recipe serializers.  This should resolve issue #9